### PR TITLE
[WIP] Add extControl support

### DIFF
--- a/aionanoleaf/stream.py
+++ b/aionanoleaf/stream.py
@@ -1,0 +1,67 @@
+"""
+Nanoleaf ext control stream
+Implementation of the streaming protocol defines here: https://forum.nanoleaf.me/docs#_9gd8j3cnjaju
+"""
+import asyncio
+from asyncio import transports
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class Color:
+    red: int
+    green: int
+    blue: int
+    white: int  # Note: white is not used
+
+    def encode(self):
+        buf = b''
+        buf += self.red.to_bytes(1, 'big')
+        buf += self.green.to_bytes(1, 'big')
+        buf += self.blue.to_bytes(1, 'big')
+        buf += self.white.to_bytes(1, 'big')
+        return buf
+
+
+@dataclass(frozen=True)
+class Update:
+    id: int
+    color: Color
+    time: int
+
+    def encode(self):
+        buf = b''
+        buf += self.id.to_bytes(2, 'big')
+        buf += self.color.encode()
+        buf += self.time.to_bytes(2, 'big')
+        return buf
+
+
+class Stream:
+    def __init__(self, transport, protocol):
+        self._transport = transport
+        self._protocol = protocol
+        pass
+
+    async def send_updates(self, updates: list[Update]) -> None:
+        buf = b''
+        count = len(updates)
+        buf += count.to_bytes(2, 'big')
+        for upd in updates:
+            buf += upd.encode()
+
+        self._transport.sendto(buf)
+
+
+class _NanoleafStreamProtocol(asyncio.DatagramProtocol):
+    def connection_made(self, transport: transports.DatagramTransport) -> None:
+        print('hey')
+
+    def connection_lost(self, exc) -> None:
+        print('oh no')
+
+    def error_received(self, exc: Exception) -> None:
+        print('err')
+
+    def datagram_received(self, data: bytes, addr: tuple[str, int]) -> None:
+        print('recv')


### PR DESCRIPTION
[extControl](https://forum.nanoleaf.me/docs#_9gd8j3cnjaju) allows a client to control each panel directly.

This PR is not completely, but it is functional. Sample code for testing it:
```python
async def main():
    async with ClientSession() as session:
        nanoleaf = aionanoleaf.Nanoleaf(session, "<host>", "<token>")
        await nanoleaf.get_info()
        s = await nanoleaf.steam()
        red = Color(255, 0, 0, 0)
        green = Color(0, 255, 0, 0)
        clear = Color(0, 0, 0, 0)
        panels = sorted(list(nanoleaf.panels), key=lambda p: (p.x_coordinate, p.y_coordinate))
        updates = [
            Update(p.id, red, 10 * idx) for idx, p in enumerate(panels)
        ]
        await s.send_updates(updates)
        await asyncio.sleep(len(panels) * 1)
        await s.send_updates([Update(p.id, clear, 0) for p in panels])
        for p in reversed(panels):
            await s.send_updates([Update(p.id, green, 10)])
            await asyncio.sleep(1)
            await s.send_updates([Update(p.id, red, 10)])
            await asyncio.sleep(1)

run(main())
```