### PR TITLE
Retrieve palette list when getting instance info

### DIFF
--- a/aionanoleaf/nanoleaf.py
+++ b/aionanoleaf/nanoleaf.py
@@ -214,6 +214,11 @@ class Nanoleaf:
         return self._panels
 
     @property
+    def palette(self) -> list[str]:
+        """Return the color palette."""
+        return self._palette
+
+    @property
     def _api_url(self) -> str:
         return f"http://{self.host}:{self.port}/api/v1"
 
@@ -293,6 +298,11 @@ class Nanoleaf:
         self._effects_list = data["effects"]["effectsList"]
         self._effect = data["effects"]["select"]
         self._panels = {Panel(panel) for panel in data["panelLayout"]["layout"]["positionData"]}
+
+        """Additional API call to retrieve palette."""
+        resp = await self._request("put", "effects", {"write": {"command": "request", "animName": data["effects"]["select"]}})
+        effect_data: InfoData = await resp.json()
+        self._palette = effect_data["palette"]
 
     async def set_state(
         self,


### PR DESCRIPTION
Hi, thanks for your work on this module!  I've been integrating (via Home Assistant) a Nanoleaf setup with other non-nanoleaf addressable LED's and have been using a kludgy work-around to supplement information provided by this module to fetch color palettes.  Obviously, the integration would be a lot tighter if palette data could be exposed directly to Home Assistant, so this simple pull request adds the functionality to this module so that it can later be utilized in a future pull request for Home Assistant.

Thanks!