### PR TITLE
Retry Nanoleaf requests

### DIFF
--- a/aionanoleaf/nanoleaf.py
+++ b/aionanoleaf/nanoleaf.py
@@ -30,7 +30,6 @@ from aiohttp import (
     ClientResponse,
     ClientSession,
     ClientTimeout,
-    ServerDisconnectedError,
     ClientConnectionError,
 )
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as f:
 
 setup(
     name="aionanoleaf",
-    version="0.2.0",
+    version="0.2.1",
     author="Milan Meulemans",
     author_email="milan.meulemans@live.be",
     description="Async Python package for the Nanoleaf API",


### PR DESCRIPTION
Hi, @milanmeu!

Thanks for working on Nanoleaf support here and in HomeAssistant.

This home-assistant issue https://github.com/home-assistant/core/issues/78230 reports some instability with recent nanoleaf support in connecting to some devices. This bug seems tricky to really root cause. Because the bug is triggered reliably on home-assistant and I've been unable to reproduce the behavior with, e.g., `curl`, I suspect this is not an issue with the Nanoleaf devices or firmware.

My _guess_ is that the problem is related to connection pool starvation, since the aionanoleaf connection pool is shared with, I think, all of home-assistant. The issue is hit on minutely intervals, where I guess there's probably a lot of activity happening. The timeouts may be too short to obtain a connection from the pool.

This PR adds retries to every request to the device API. This isn't an ideal solution (versus actually understanding and fixing the root cause), but in my installation it completely fixes the bug.

Thanks!
- Tricia