### PR TITLE
Add basic 4D scene control

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -141,4 +141,3 @@ cython_debug/
 .idea/
 example.py
 tempCodeRunnerFile.py
-setup.py

--- a/.gitignore
+++ b/.gitignore
@@ -141,3 +141,4 @@ cython_debug/
 .idea/
 example.py
 tempCodeRunnerFile.py
+setup.py

--- a/.gitignore
+++ b/.gitignore
@@ -139,3 +139,5 @@ cython_debug/
 
 #JetBrains
 .idea/
+example.py
+tempCodeRunnerFile.py

--- a/aionanoleaf/events.py
+++ b/aionanoleaf/events.py
@@ -22,6 +22,7 @@ from abc import ABC
 
 from .typing import (
     EffectsEventData,
+    #EmersionEventData,
     LayoutEventData,
     StateEventData,
     TouchEventData,
@@ -114,6 +115,34 @@ class EffectsEvent(Event):
     def effect(self) -> str:
         """Return the active effect."""
         return self._event_data["value"]
+    
+# class EmersionEvent(Event):
+#     """Nanoleaf Emersion (4D) event. Not implemented yet since there are no events for this in the api :("""
+
+#     EVENT_TYPE_ID = 5
+
+#     def __init__(self, event_data: EmersionEventData) -> None:
+#         """Init Nanoleaf emersion event."""
+#         self._event_data = event_data
+
+#     @property
+#     def attribute_id(self) -> int:
+#         """Return event attribute ID."""
+#         return self._event_data["attr"]
+
+#     @property
+#     def effect(self) -> str:
+#         """Return the active Emersion mode."""
+#         return self._event_data["value"]
+    
+#     def emersion(self) -> int:
+#         """Return event attribute."""
+#         return {
+#             1: 6, #1D
+#             2: 2, #2D
+#             3: 3, #3D
+#             4: 5, #4D
+#         }[self.attribute_id]
 
 
 class TouchEvent(Event):

--- a/aionanoleaf/events.py
+++ b/aionanoleaf/events.py
@@ -22,7 +22,6 @@ from abc import ABC
 
 from .typing import (
     EffectsEventData,
-    #EmersionEventData,
     LayoutEventData,
     StateEventData,
     TouchEventData,
@@ -115,35 +114,6 @@ class EffectsEvent(Event):
     def effect(self) -> str:
         """Return the active effect."""
         return self._event_data["value"]
-    
-# class EmersionEvent(Event):
-#     """Nanoleaf Emersion (4D) event. Not implemented yet since there are no events for this in the api :("""
-
-#     EVENT_TYPE_ID = 5
-
-#     def __init__(self, event_data: EmersionEventData) -> None:
-#         """Init Nanoleaf emersion event."""
-#         self._event_data = event_data
-
-#     @property
-#     def attribute_id(self) -> int:
-#         """Return event attribute ID."""
-#         return self._event_data["attr"]
-
-#     @property
-#     def effect(self) -> str:
-#         """Return the active Emersion mode."""
-#         return self._event_data["value"]
-    
-#     def emersion(self) -> int:
-#         """Return event attribute."""
-#         return {
-#             1: 6, #1D
-#             2: 2, #2D
-#             3: 3, #3D
-#             4: 5, #4D
-#         }[self.attribute_id]
-
 
 class TouchEvent(Event):
     """Nanoleaf touch event."""

--- a/aionanoleaf/exceptions.py
+++ b/aionanoleaf/exceptions.py
@@ -25,6 +25,8 @@ class NanoleafException(Exception):
 class InvalidEffect(NanoleafException, ValueError):
     """Invalid effect specified."""
 
+class InvalidEmersion(NanoleafException, ValueError):
+    """Invalid emersion specified."""
 
 class InvalidToken(NanoleafException):
     """Invalid token specified."""

--- a/aionanoleaf/nanoleaf.py
+++ b/aionanoleaf/nanoleaf.py
@@ -322,7 +322,7 @@ class Nanoleaf:
         self._effects_list = data["effects"]["effectsList"]
         self._effect = data["effects"]["select"]
         self._panels = {Panel(panel) for panel in data["panelLayout"]["layout"]["positionData"]}
-        #4D/Emersion implementation.
+        #4D/Emersion implementation. (This is how they spelt emersion in the API, probably should be Immersion)
         self._emersion_list = [6,2,3,5] # 6 = 1D, 2 = 2D, 3 = 3D, 5 = 4D (No way to get the list from the device)
         emersion_request = await self._request("put", "effects", {"write":{"command":"getScreenMirrorMode"}})
         emersion_data: InfoData = await emersion_request.json()

--- a/aionanoleaf/nanoleaf.py
+++ b/aionanoleaf/nanoleaf.py
@@ -510,7 +510,7 @@ class Nanoleaf:
                                 effects_event = EffectsEvent(event_data)
                                 self._effect = effects_event.effect
                                 if effects_event.effect == "*Emersion*":
-                                   self.get_emersion()
+                                   await self.get_emersion()
                                 if effects_callback is not None:
                                     asyncio.create_task(effects_callback(effects_event))
                             elif event_type_id == TouchEvent.EVENT_TYPE_ID:

--- a/aionanoleaf/typing.py
+++ b/aionanoleaf/typing.py
@@ -76,7 +76,10 @@ class EffectsData(TypedDict):
 
     select: str
     effectsList: list[str]
-
+    
+class EmersionData(TypedDict):
+    """Nanoleaf API Emersion data."""
+    screenMirrorMode: int
 
 class InfoData(TypedDict):
     """Nanoleaf API info."""
@@ -90,6 +93,7 @@ class InfoData(TypedDict):
     state: StateData
     effects: EffectsData
     panelLayout: PanelLayoutData
+    emersion: EmersionData
 
 
 class CanvasInfoData(InfoData):
@@ -122,6 +126,12 @@ class EffectsEventData(TypedDict):
 
     attr: int
     value: str
+    
+#class EmersionEventData(TypedDict):
+#    """Nanoleaf API Emersion event data."""
+
+#    attr: int
+
 
 
 class TouchEventData(TypedDict):

--- a/aionanoleaf/typing.py
+++ b/aionanoleaf/typing.py
@@ -129,6 +129,7 @@ class EffectsEventData(TypedDict):
     
 #class EmersionEventData(TypedDict):
 #    """Nanoleaf API Emersion event data."""
+#Keeping as a place holder until events are added
 
 #    attr: int
 

--- a/aionanoleaf/typing.py
+++ b/aionanoleaf/typing.py
@@ -126,13 +126,6 @@ class EffectsEventData(TypedDict):
 
     attr: int
     value: str
-    
-#class EmersionEventData(TypedDict):
-#    """Nanoleaf API Emersion event data."""
-
-#    attr: int
-
-
 
 class TouchEventData(TypedDict):
     """Nanoleaf API Touch event data."""

--- a/setup.py
+++ b/setup.py
@@ -5,10 +5,10 @@ with open("README.md", "r", encoding="utf-8") as f:
 
 setup(
     name="aionanoleaf4d",
-    version="0.2.2",
+    version="0.2.1",
     author="Milan Meulemans",
     author_email="milan.meulemans@live.be",
-    description="Async Python package for the Nanoleaf API with basic 4d support",
+    description="Async Python package for the Nanoleaf API",
     keywords="nanoleaf api canvas shapes elements light panels",
     license="LGPLv3+",
     long_description=long_description,

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ with open("README.md", "r", encoding="utf-8") as f:
     long_description = f.read()
 
 setup(
-    name="aionanoleaf4d",
+    name="aionanoleaf",
     version="0.2.1",
     author="Milan Meulemans",
     author_email="milan.meulemans@live.be",

--- a/setup.py
+++ b/setup.py
@@ -4,11 +4,11 @@ with open("README.md", "r", encoding="utf-8") as f:
     long_description = f.read()
 
 setup(
-    name="aionanoleaf",
-    version="0.2.1",
+    name="aionanoleaf4d",
+    version="0.2.2",
     author="Milan Meulemans",
     author_email="milan.meulemans@live.be",
-    description="Async Python package for the Nanoleaf API",
+    description="Async Python package for the Nanoleaf API with basic 4d support",
     keywords="nanoleaf api canvas shapes elements light panels",
     license="LGPLv3+",
     long_description=long_description,


### PR DESCRIPTION
Hey there,

I added basic 4D scene control for the new ambilight that nanoleaf made. It is a bit of a hack since there's no event to get the active 4D mode and the mode cannot be set as a string but, instead an int so I accounted for that conversion too. (The api really does suck lol). There's also no way to get the list of available modes from the device but there will probably only ever be 4. The whole thing is kind of a hack so I can understand if this wouldn't get merged. If you get a chance please take a look and let me know of any suggestions, changes or any issues of the PR!

Thanks,
Jonathan